### PR TITLE
Fix flake8 e501 line too long

### DIFF
--- a/aamva_standard/barcode.py
+++ b/aamva_standard/barcode.py
@@ -19,7 +19,8 @@ def trim_to_indicator(_str: str, indicator: str) -> str:
 def read_file_header(file: str) -> dict:
     file = trim_to_indicator(file, COMPLIANCE_INDICATOR)
     if file[4:9] != "ANSI ":
-        raise ValueError(f"header file type missing \"{file[4:9]}\" != \"ANSI \"")
+        raise ValueError(
+            f"header file type missing \"{file[4:9]}\" != \"ANSI \"")
     header = dict(
         data_element_separator=str(file[1]),
         record_separator=str(file[2]),
@@ -36,18 +37,35 @@ def read_file_header(file: str) -> dict:
     return header
 
 
-def read_subfile_designator(file: str, aamva_version_number: int, designator_index: int) -> tuple:
+def read_subfile_designator(
+        file: str,
+        aamva_version_number: int,
+        designator_index: int) -> tuple:
     file = trim_to_indicator(file, COMPLIANCE_INDICATOR)
-    cursor = designator_index * DESIGNATOR_LENGTH + header_length(aamva_version_number)
-    return (str(file[cursor:cursor + 2]), int(file[cursor + 2:cursor + 6]), int(file[cursor + 6:cursor + 10]))
+    cursor = designator_index * DESIGNATOR_LENGTH + \
+        header_length(aamva_version_number)
+    return (
+        str(file[cursor:cursor + 2]),
+        int(file[cursor + 2:cursor + 6]),
+        int(file[cursor + 6:cursor + 10]))
 
 
-def read_subfile(file: str, data_element_separator: str, segment_terminator: str, subfile_type: str, offset: int, length: int) -> dict:
+def read_subfile(
+        file: str,
+        data_element_separator: str,
+        segment_terminator: str,
+        subfile_type: str,
+        offset: int,
+        length: int) -> dict:
     end_offset = offset + length - 1
     if file[offset:offset + 2] != subfile_type:
-        raise ValueError(f"Subfile is missing subfile type {ascii(file[offset:offset + 2])} != {ascii(subfile_type)}")
+        raise ValueError(
+            f"Subfile is missing subfile type {ascii(file[offset:offset + 2])}\
+                != {ascii(subfile_type)}")
     elif file[end_offset] != segment_terminator:
-        raise ValueError(f"Subfile is missing segment terminator {ascii(file[end_offset])} != {ascii(segment_terminator)}")
+        raise ValueError(
+            f"Subfile is missing segment terminator {ascii(file[end_offset])} \
+                != {ascii(segment_terminator)}")
     subfile = {}
     elements = filter(
         None, file[offset + 2:end_offset].split(data_element_separator))
@@ -63,8 +81,13 @@ def read_file(file: str) -> dict:
         raise ValueError("number of entries cannot be less than 1")
     subfiles = {}
     for i in range(header["number_of_entries"]):
-        designator = read_subfile_designator(file, header["aamva_version_number"], i)
-        subfiles[designator[0]] = read_subfile(file, header["data_element_separator"], header["segment_terminator"], *designator)
+        designator = read_subfile_designator(
+            file, header["aamva_version_number"], i)
+        subfiles[designator[0]] = read_subfile(
+            file,
+            header["data_element_separator"],
+            header["segment_terminator"],
+            *designator)
     return {
         "header": header,
         "subfiles": subfiles

--- a/aamva_standard/test_barcode.py
+++ b/aamva_standard/test_barcode.py
@@ -113,7 +113,10 @@ testdata = (
 )
 
 
-@pytest.mark.parametrize("version, expects", ((1, 19), (2, 21)), ids=("AAMVA Version 1", "AAMVA Version 2+"))
+@pytest.mark.parametrize(
+    "version, expects",
+    ((1, 19), (2, 21)),
+    ids=("AAMVA Version 1", "AAMVA Version 2+"))
 def test_header_length_lambda_function(version, expects):
     assert barcode.header_length(version) == expects
 
@@ -138,28 +141,53 @@ def test_read_file_header_raises_file_type_missing():
         barcode.read_file_header("@\n\x1e\rLLLL 999999100201")
 
 
-@pytest.mark.parametrize("test_string, designators, expects", testdata, ids=testdata_ids)
+@pytest.mark.parametrize(
+    "test_string, designators, expects", testdata, ids=testdata_ids)
 def test_can_read_subfile_designator(test_string, designators, expects):
     for index, designator in enumerate(designators):
-        assert barcode.read_subfile_designator(test_string, expects["header"]["aamva_version_number"], index) == designator
+        assert barcode.read_subfile_designator(
+            test_string,
+            expects["header"]["aamva_version_number"],
+            index) == designator
 
 
-@pytest.mark.parametrize("test_string, designators, expects", testdata, ids=testdata_ids)
+@pytest.mark.parametrize(
+    "test_string, designators, expects", testdata, ids=testdata_ids)
 def test_can_read_subfile(test_string, designators, expects):
-    assert barcode.read_subfile(test_string, expects["header"]["data_element_separator"], expects["header"]["segment_terminator"], *designators[0]) == expects["subfiles"]["DL"]
-    assert barcode.read_subfile(test_string, expects["header"]["data_element_separator"], expects["header"]["segment_terminator"], *designators[1]) == expects["subfiles"]["ZV"]
+    assert barcode.read_subfile(
+        test_string,
+        expects["header"]["data_element_separator"],
+        expects["header"]["segment_terminator"],
+        *designators[0]) == expects["subfiles"]["DL"]
+    assert barcode.read_subfile(
+        test_string,
+        expects["header"]["data_element_separator"],
+        expects["header"]["segment_terminator"],
+        *designators[1]) == expects["subfiles"]["ZV"]
 
 
-@pytest.mark.parametrize("test_string, designators, expects", testdata, ids=testdata_ids)
-def test_read_subfile_raises_missing_subfile_type(test_string, designators, expects):
+@pytest.mark.parametrize(
+    "test_string, designators, expects", testdata, ids=testdata_ids)
+def test_read_subfile_raises_missing_subfile_type(
+        test_string, designators, expects):
     with pytest.raises(ValueError, match="missing subfile type"):
-        barcode.read_subfile(test_string, expects["header"]["data_element_separator"], expects["header"]["segment_terminator"], designators[0][0], designators[0][1] - 1, designators[0][2])
+        barcode.read_subfile(
+            test_string,
+            expects["header"]["data_element_separator"],
+            expects["header"]["segment_terminator"],
+            designators[0][0], designators[0][1] - 1, designators[0][2])
 
 
-@pytest.mark.parametrize("test_string, designators, expects", testdata, ids=testdata_ids)
-def test_read_subfile_raises_missing_segment_terminator(test_string, designators, expects):
+@pytest.mark.parametrize(
+    "test_string, designators, expects", testdata, ids=testdata_ids)
+def test_read_subfile_raises_missing_segment_terminator(
+        test_string, designators, expects):
     with pytest.raises(ValueError, match="missing segment terminator"):
-        barcode.read_subfile(test_string, expects["header"]["data_element_separator"], expects["header"]["segment_terminator"], designators[0][0], designators[0][1], designators[0][2] - 1)
+        barcode.read_subfile(
+            test_string,
+            expects["header"]["data_element_separator"],
+            expects["header"]["segment_terminator"],
+            designators[0][0], designators[0][1], designators[0][2] - 1)
 
 
 @pytest.mark.parametrize("test_string, _, expects", testdata, ids=testdata_ids)
@@ -168,5 +196,7 @@ def test_can_read_file(test_string, _, expects):
 
 
 def test_read_file_raises_number_of_entries_cannot_be_less_than_1():
-    with pytest.raises(ValueError, match="number of entries cannot be less than 1"):
+    with pytest.raises(
+            ValueError,
+            match="number of entries cannot be less than 1"):
         barcode.read_file("@\n\x1e\rANSI 6360000100")


### PR DESCRIPTION
Got them all. `flake8` now returns no errors