### PR TITLE
(chore) Return barcode file as dict

### DIFF
--- a/tests/test_barcode.py
+++ b/tests/test_barcode.py
@@ -12,28 +12,44 @@ barcode_testdata = (
         "DAK123459999  \nDARDM  \nDAS          \nDAT     \nDAU509\nDAW175\n" +
         "DAYBL \nDAZBR \nDBA20011201\nDBB19761123\nDBCM\nDBD19961201\r" +
         "ZVZVAJURISDICTIONDEFINEDELEMENT\r",
-        (636000, 1, 2, 0),
-        (("DL", 39, 187), ("ZV", 226, 32)),
+        {
+            "issuer_id": 636000,
+            "aamva_version": 1,
+            "number_of_entries": 2,
+            "jurisdiction_version": 0},
         (
-            ("DL", {
-                'DAQ': '0123456789ABC',
-                'DAA': 'PUBLIC,JOHN,Q',
-                'DAG': '123 MAIN STREET',
-                'DAI': 'ANYTOWN',
-                'DAJ': 'VA',
-                'DAK': '123459999  ',
-                'DAR': 'DM  ',
-                'DAS': '          ',
-                'DAT': '     ',
-                'DAU': '509',
-                'DAW': '175',
-                'DAY': 'BL ',
-                'DAZ': 'BR ',
-                'DBA': '20011201',
-                'DBB': '19761123',
-                'DBC': 'M',
-                'DBD': '19961201'}),
-            ("ZV", {'ZVA': 'JURISDICTIONDEFINEDELEMENT'}))),
+            {
+                "subfile_type": "DL",
+                "offset": 39,
+                "length": 187},
+            {
+                "subfile_type": "ZV",
+                "offset": 226,
+                "length": 32}),
+        (
+            {
+                "subfile_type": "DL",
+                "elements": {
+                    'DAQ': '0123456789ABC',
+                    'DAA': 'PUBLIC,JOHN,Q',
+                    'DAG': '123 MAIN STREET',
+                    'DAI': 'ANYTOWN',
+                    'DAJ': 'VA',
+                    'DAK': '123459999  ',
+                    'DAR': 'DM  ',
+                    'DAS': '          ',
+                    'DAT': '     ',
+                    'DAU': '509',
+                    'DAW': '175',
+                    'DAY': 'BL ',
+                    'DAZ': 'BR ',
+                    'DBA': '20011201',
+                    'DBB': '19761123',
+                    'DBC': 'M',
+                    'DBD': '19961201'}},
+            {
+                "subfile_type": "ZV",
+                "elements": {'ZVA': 'JURISDICTIONDEFINEDELEMENT'}})),
     (
         # AAMVA Version 10
         10,
@@ -43,39 +59,55 @@ barcode_testdata = (
         "DAU068 in\nDAYBRO\nDAG2300 WEST BROAD STREET\nDAIRICHMOND\nDAJVA\n" +
         "DAK232690000  \nDCF2424244747474786102204\nDCGUSA\nDCK123456789\n" +
         "DDAF\nDDB06062018\nDDC06062020\nDDD1\rZVZVA01\r",
-        (636000, 10, 2, 1),
-        (("DL", 41, 278), ("ZV", 319, 8)),
+        {
+            "issuer_id": 636000,
+            "aamva_version": 10,
+            "number_of_entries": 2,
+            "jurisdiction_version": 1},
         (
-            ("DL", {
-                'DAQ': 'T64235789',
-                'DCS': 'SAMPLE',
-                'DDE': 'N',
-                'DAC': 'MICHAEL',
-                'DDF': 'N',
-                'DAD': 'JOHN',
-                'DDG': 'N',
-                'DCU': 'JR',
-                'DCA': 'D',
-                'DCB': 'K',
-                'DCD': 'PH',
-                'DBD': '06062019',
-                'DBB': '06061986',
-                'DBA': '12102024',
-                'DBC': '1',
-                'DAU': '068 in',
-                'DAY': 'BRO',
-                'DAG': '2300 WEST BROAD STREET',
-                'DAI': 'RICHMOND',
-                'DAJ': 'VA',
-                'DAK': '232690000  ',
-                'DCF': '2424244747474786102204',
-                'DCG': 'USA',
-                'DCK': '123456789',
-                'DDA': 'F',
-                'DDB': '06062018',
-                'DDC': '06062020',
-                'DDD': '1'}),
-            ("ZV", {'ZVA': '01'}))))
+            {
+                "subfile_type": "DL",
+                "offset": 41,
+                "length": 278},
+            {
+                "subfile_type": "ZV",
+                "offset": 319,
+                "length": 8}),
+        (
+            {
+                "subfile_type": "DL",
+                "elements": {
+                    'DAQ': 'T64235789',
+                    'DCS': 'SAMPLE',
+                    'DDE': 'N',
+                    'DAC': 'MICHAEL',
+                    'DDF': 'N',
+                    'DAD': 'JOHN',
+                    'DDG': 'N',
+                    'DCU': 'JR',
+                    'DCA': 'D',
+                    'DCB': 'K',
+                    'DCD': 'PH',
+                    'DBD': '06062019',
+                    'DBB': '06061986',
+                    'DBA': '12102024',
+                    'DBC': '1',
+                    'DAU': '068 in',
+                    'DAY': 'BRO',
+                    'DAG': '2300 WEST BROAD STREET',
+                    'DAI': 'RICHMOND',
+                    'DAJ': 'VA',
+                    'DAK': '232690000  ',
+                    'DCF': '2424244747474786102204',
+                    'DCG': 'USA',
+                    'DCK': '123456789',
+                    'DDA': 'F',
+                    'DDB': '06062018',
+                    'DDC': '06062020',
+                    'DDD': '1'}},
+            {
+                "subfile_type": "ZV",
+                "elements": {'ZVA': '01'}})))
 
 barcode_testdata_ids = tuple(map(lambda v: f"Version {v[0]}", barcode_testdata))
 
@@ -152,10 +184,10 @@ class TestParseFileHeaderFunction:
             barcode.parse_file_header(barcode_string[:length - 1])
 
     @pytest.mark.parametrize("barcode_string, header", header_testdata, ids=barcode_testdata_ids)
-    def test_should_successfully_return_file_header_tuple(self, barcode_string, header):
+    def test_should_successfully_return_file_header_dict(self, barcode_string, header):
         test_header = barcode.parse_file_header(barcode_string)
+        assert type(test_header) is dict
         assert test_header == header
-        assert type(test_header) is barcode.FileHeader
 
 
 class TestParseSubfileDesignatorFunction:
@@ -169,10 +201,10 @@ class TestParseSubfileDesignatorFunction:
 
     @pytest.mark.parametrize("index", (0, 1), ids=("Subfile Designator 0", "Subfile Designator 1"))
     @pytest.mark.parametrize("version, barcode_string, designators", testdata, ids=barcode_testdata_ids)
-    def test_should_successfully_return_subfile_designator_tuple(self, version, barcode_string, designators, index):
+    def test_should_successfully_return_subfile_designator_dict(self, version, barcode_string, designators, index):
         test_subfile_designator = barcode.parse_subfile_designator(barcode_string, version, index)
+        assert type(test_subfile_designator) is dict
         assert test_subfile_designator == designators[index]
-        assert type(test_subfile_designator) is barcode.SubfileDesignator
 
 
 class TestParseSubfileFunction:
@@ -183,30 +215,30 @@ class TestParseSubfileFunction:
     @pytest.mark.parametrize("barcode_string, designators", raises_testdata, ids=barcode_testdata_ids)
     def test_should_raise_value_error_when_subfile_too_short(self, index, barcode_string, designators):
         with pytest.raises(ValueError, match="too short"):
-            length = designators[index][1] + designators[index][2] - 1
+            length = designators[index]["offset"] + designators[index]["length"] - 1
             barcode.parse_subfile(barcode_string[:length], designators[index])
 
     @pytest.mark.parametrize("index", (0, 1), ids=("Subfile 0", "Subfile 1"))
     @pytest.mark.parametrize("barcode_string, designators", raises_testdata, ids=barcode_testdata_ids)
     def test_should_raise_value_error_when_missing_subfile_type(self, index, barcode_string, designators, replace_char_at_index):
         with pytest.raises(ValueError, match="missing subfile type"):
-            barcode_string = replace_char_at_index(barcode_string, designators[index][1])
+            barcode_string = replace_char_at_index(barcode_string, designators[index]["offset"])
             barcode.parse_subfile(barcode_string, designators[index])
 
     @pytest.mark.parametrize("index", (0, 1), ids=("Subfile 0", "Subfile 1"))
     @pytest.mark.parametrize("barcode_string, designators", raises_testdata, ids=barcode_testdata_ids)
     def test_should_raise_value_error_when_missing_segment_terminator(self, index, barcode_string, designators, replace_char_at_index):
         with pytest.raises(ValueError, match="missing segment terminator"):
-            subfile_end = designators[index][1] + designators[index][2] - 1
+            subfile_end = designators[index]["offset"] + designators[index]["length"] - 1
             barcode_string = replace_char_at_index(barcode_string, subfile_end)
             barcode.parse_subfile(barcode_string, designators[index])
 
     @pytest.mark.parametrize("index", (0, 1), ids=("Subfile 0", "Subfile 1"))
     @pytest.mark.parametrize("barcode_string, designators, subfiles", subfile_testdata, ids=barcode_testdata_ids)
-    def test_should_successfully_return_subfile_tuple(self, index, barcode_string, designators, subfiles):
+    def test_should_successfully_return_subfile_dict(self, index, barcode_string, designators, subfiles):
         test_subfile = barcode.parse_subfile(barcode_string, designators[index])
+        assert type(test_subfile) is dict
         assert test_subfile == subfiles[index]
-        assert type(test_subfile) is barcode.Subfile
 
 
 class TestParseBarcodeStringFunction:
@@ -221,7 +253,7 @@ class TestParseBarcodeStringFunction:
             barcode.parse_barcode_string(barcode_string)
 
     @pytest.mark.parametrize("barcode_string, header, subfiles", file_testdata, ids=barcode_testdata_ids)
-    def test_should_successfully_return_barcode_file_tuple(self, barcode_string, header, subfiles):
+    def test_should_successfully_return_barcode_file_dict(self, barcode_string, header, subfiles):
         barcode_file = barcode.parse_barcode_string(barcode_string)
-        assert barcode_file == (header, subfiles)
-        assert type(barcode_file) is barcode.BarcodeFile
+        assert type(barcode_file) is dict
+        assert barcode_file == {"header": header, "subfiles": subfiles}


### PR DESCRIPTION
This PR changes the returned barcode from `tuple` to `dict` improving operability with JSON.

Tests updated to reflect changes

Fixes #16 